### PR TITLE
Fix the health data query which doesn't reference date range bug.

### DIFF
--- a/HealthLens/ContentViewModel.swift
+++ b/HealthLens/ContentViewModel.swift
@@ -417,9 +417,11 @@ class ContentViewModel: ObservableObject {
       // fetching in a dispatch group
       dispatchGroup.enter()
 
+      let dateRange = HKQuery.predicateForSamples(withStart: startDate, end: endDate, options: [])
+        
       // calling the function
       let query = HKSampleQuery(
-        sampleType: quantityType, predicate: nil, limit: 1000, sortDescriptors: nil
+        sampleType: quantityType, predicate: dateRange, limit: 3000, sortDescriptors: nil
       ) { query, sample, error in
         if let error = error {
           logger.error("Failed to fetch data with error \(error)")


### PR DESCRIPTION
[Issue] I select a date range but the data exported does not reference the date range.
[Fix] I modify the query predict to use date range as predict and also increase limit from 1000 to 3000 to tolerance more data.